### PR TITLE
sign_up修正

### DIFF
--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,6 +1,6 @@
 = render "products/header"
 .ad_all
-= form_for(resource, as: resource_name, url: signup_index_path(resource_name)) do |f|
+= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = render "devise/shared/error_messages", resource: resource
   .ad
     .ad__ad


### PR DESCRIPTION
#WHAT
会員登録後のログアウトボタンが出てこなかった為、new.html.hamlの3行目を修正。


#WHY
会員登録後はログインページのみを表示させるようにする為。